### PR TITLE
Enhance image loading with progress and lazy assets

### DIFF
--- a/index.html
+++ b/index.html
@@ -320,7 +320,8 @@ let audioElements = {
 };
 
 // 画像ファイル名
-const imageFiles = ['2.PNG', '3.PNG', '4.PNG', '5.PNG', '6.PNG', '8.PNG', '9.PNG', '11.PNG', '12.PNG'];
+const requiredImageFiles = ['2.PNG', '3.PNG', '4.PNG', '5.PNG', '6.PNG', '8.PNG', '9.PNG', '11.PNG', '12.PNG'];
+const optionalImageFiles = ['1.PNG', '7.PNG', '10.PNG'];
 
 // オーディオ初期化
 function initializeAudio() {
@@ -581,14 +582,17 @@ function simplifyPolygon(points, maxVertices) {
 }
 
 // 画像をプリロードする関数
-function preloadImages() {
-    const loadingPromises = imageFiles.map(filename => {
-        return new Promise((resolve, reject) => {
+function preloadImages(imageList, onProgress) {
+    let loaded = 0;
+    const total = imageList.length;
+
+    const loadingPromises = imageList.map(filename => {
+        return new Promise((resolve) => {
             const img = new Image();
             img.onload = () => {
                 const scale = calculateOptimalScale(img.width, img.height, GAME_CONFIG.animal.targetSize);
                 const polygon = createPolygonFromImage({ image: img, scale: scale });
-                
+
                 gameState.loadedImages[filename] = {
                     image: img,
                     scale: scale,
@@ -596,19 +600,23 @@ function preloadImages() {
                     height: img.height * scale,
                     polygon: polygon
                 };
-                resolve();
+                loaded++;
+                if (onProgress) onProgress(loaded, total);
+                resolve({ status: 'fulfilled' });
             };
             img.onerror = () => {
                 console.warn(`画像の読み込みに失敗: ${filename}`);
-                reject(new Error(`Failed to load ${filename}`));
+                loaded++;
+                if (onProgress) onProgress(loaded, total);
+                resolve({ status: 'rejected' });
             };
             img.src = filename;
         });
     });
-    
-    return Promise.allSettled(loadingPromises).then(results => {
+
+    return Promise.all(loadingPromises).then(results => {
         const successful = results.filter(result => result.status === 'fulfilled').length;
-        console.log(`${successful}/${imageFiles.length} 個の画像を読み込みました`);
+        console.log(`${successful}/${total} 個の画像を読み込みました`);
         return successful > 0;
     });
 }
@@ -1001,37 +1009,43 @@ function setupEventListeners() {
 
 // ゲーム初期化とスタート
 async function startGame() {
-    document.getElementById('loadingText').textContent = '画像を読み込み中...';
-    
+    const loadingText = document.getElementById('loadingText');
+    loadingText.textContent = `画像を読み込み中... 0/${requiredImageFiles.length}`;
+
     // オーディオ初期化
     initializeAudio();
     enableAudioOnUserInteraction();
-    
+
     try {
-        const success = await preloadImages();
-        
+        const success = await preloadImages(requiredImageFiles, (loaded, total) => {
+            loadingText.textContent = `画像を読み込み中... ${loaded}/${total}`;
+        });
+
         if (success) {
             gameState.imagesLoaded = true;
-            document.getElementById('loadingText').style.display = 'none';
+            loadingText.style.display = 'none';
             document.getElementById('scoreDisplay').style.display = 'block';
             document.getElementById('audioControls').style.display = 'flex';
             document.getElementById('controls').style.display = 'flex';
-            
+
             initializeGame();
-            
+
+            // オプション画像を遅延読み込み
+            preloadImages(optionalImageFiles);
+
             console.log('ゲームが開始されました！');
             console.log('操作: 矢印キー/WASD で移動・回転、スペース/S で落下、R でリセット、M でBGM切替');
             console.log('⚠️ 動物が土台から落ちるとゲームオーバーです！');
         } else {
-            document.getElementById('loadingText').textContent = '画像の読み込みに失敗しました。画像ファイル（1.PNG～12.PNG）を確認してください。';
-            document.getElementById('loadingText').style.color = '#ff0000';
+            loadingText.textContent = '画像の読み込みに失敗しました。画像ファイル（1.PNG～12.PNG）を確認してください。';
+            loadingText.style.color = '#ff0000';
         }
     } catch (error) {
         console.error('ゲーム初期化エラー:', error);
-        document.getElementById('loadingText').textContent = 'ゲームの初期化に失敗しました。';
-        document.getElementById('loadingText').style.color = '#ff0000';
+        loadingText.textContent = 'ゲームの初期化に失敗しました。';
+        loadingText.style.color = '#ff0000';
     }
 }
 
 // ページ読み込み完了後にゲーム開始
-window.addEventListener('load', startGame);
+window.addEventListener('DOMContentLoaded', startGame);


### PR DESCRIPTION
## Summary
- Switch game startup to `DOMContentLoaded`
- Show image loading progress and split required vs optional assets
- Defer optional asset loading until after game start

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/moura_tower/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689ccec2a57c8332b51e3f5f632bafed