### PR TITLE
Refactor service worker and optimize caching

### DIFF
--- a/index.html
+++ b/index.html
@@ -229,7 +229,7 @@
 // Service Worker登録
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register('data:application/javascript;base64,c2VsZi5hZGRFdmVudExpc3RlbmVyKCdpbnN0YWxsJywgZSA9PiB7CiAgZS53YWl0VW50aWwoCiAgICBjYWNoZXMub3BlbignYW5pbWFsLXRvd2VyLXYxJykudGhlbihjYWNoZSA9PiB7CiAgICAgIHJldHVybiBjYWNoZS5hZGRBbGwoWwogICAgICAgICcuLycsCiAgICAgICAgJy4vaW5kZXguaHRtbCcsCiAgICAgICAgJy4vYmdtLm1wMycsCiAgICAgICAgJy4vMS5QTkcnLAogICAgICAgICcuLzIuUE5HJywKICAgICAgICAnLi8zLlBORycsCiAgICAgICAgJy4vNC5QTkcnLAogICAgICAgICcuLzUuUE5HJywKICAgICAgICAnLi82LlBORycsCiAgICAgICAgJy4vNy5QTkcnLAogICAgICAgICcuLzguUE5HJywKICAgICAgICAnLi85LlBORycsCiAgICAgICAgJy4vMTAuUE5HJywKICAgICAgICAnLi8xMS5QTkcnLAogICAgICAgICcuLzEyLlBORycKICAgICAgXSk7CiAgICB9KQogICk7Cn0pOwoKc2VsZi5hZGRFdmVudExpc3RlbmVyKCdmZXRjaCcsIGUgPT4gewogIGUucmVzcG9uZFdpdGgoCiAgICBjYWNoZXMubWF0Y2goZS5yZXF1ZXN0KS50aGVuKHJlc3BvbnNlID0+IHsKICAgICAgcmV0dXJuIHJlc3BvbnNlIHx8IGZldGNoKGUucmVxdWVzdCk7CiAgICB9KQogICk7Cn0pOw==')
+    navigator.serviceWorker.register('sw.js')
       .then(registration => {
         console.log('SW registered: ', registration);
       })

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,70 @@
+const CACHE_NAME = 'animal-tower-v1';
+const CORE_ASSETS = [
+  './',
+  './index.html'
+];
+
+const IMAGE_ASSETS = [
+  './1.PNG',
+  './2.PNG',
+  './3.PNG',
+  './4.PNG',
+  './5.PNG',
+  './6.PNG',
+  './7.PNG',
+  './8.PNG',
+  './9.PNG',
+  './10.PNG',
+  './11.PNG',
+  './12.PNG'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(async cache => {
+      const results = await Promise.allSettled(CORE_ASSETS.map(url => cache.add(url)));
+      results.forEach((result, index) => {
+        if (result.status === 'rejected') {
+          console.warn(`Failed to cache ${CORE_ASSETS[index]}`, result.reason);
+        }
+      });
+    })
+  );
+});
+
+// Cache large images after activation without blocking install
+self.addEventListener('activate', event => {
+  event.waitUntil(self.clients.claim());
+  caches.open(CACHE_NAME).then(cache => {
+    IMAGE_ASSETS.forEach(url => {
+      cache.add(url).catch(err => console.warn(`Image cache failed: ${url}`, err));
+    });
+  });
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => {
+      if (response) {
+        return response;
+      }
+
+      return fetch(event.request).then(networkResponse => {
+        if (!networkResponse || networkResponse.status !== 200 || networkResponse.type !== 'basic') {
+          return networkResponse;
+        }
+
+        const responseClone = networkResponse.clone();
+        caches.open(CACHE_NAME).then(cache => {
+          cache.put(event.request, responseClone);
+        });
+
+        return networkResponse;
+      });
+    }).catch(error => {
+      console.error('Fetch failed:', error);
+      return fetch(event.request);
+    })
+  );
+});
+


### PR DESCRIPTION
## Summary
- move inline service worker into standalone `sw.js`
- drop missing audio from precache and defer large image caching
- add error handling so failed cache fetches don't abort install

## Testing
- ⚠️ `npm test` (fails: could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_689ccec0e2ec8332a2294a8f11dcec6f