### PR TITLE
Refactor service worker setup

### DIFF
--- a/index.html
+++ b/index.html
@@ -230,7 +230,7 @@
 // Service Worker登録
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register('data:application/javascript;base64,c2VsZi5hZGRFdmVudExpc3RlbmVyKCdpbnN0YWxsJywgZSA9PiB7CiAgZS53YWl0VW50aWwoCiAgICBjYWNoZXMub3BlbignYW5pbWFsLXRvd2VyLXYxJykudGhlbihjYWNoZSA9PiB7CiAgICAgIHJldHVybiBjYWNoZS5hZGRBbGwoWwogICAgICAgICcuLycsCiAgICAgICAgJy4vaW5kZXguaHRtbCcsCiAgICAgICAgJy4vc2FtcGxlL21hdHRlci5taW4uanMnLAogICAgICAgICcuL2JnbS5tcDMnLAogICAgICAgICcuLzEuUE5HJywKICAgICAgICAnLi8yLlBORycsCiAgICAgICAgJy4vMy5QTkcnLAogICAgICAgICcuLzQuUE5HJywKICAgICAgICAnLi81LlBORycsCiAgICAgICAgJy4vNi5QTkcnLAogICAgICAgICcuLzcuUE5HJywKICAgICAgICAnLi84LlBORycsCiAgICAgICAgJy4vOS5QTkcnLAogICAgICAgICcuLzEwLlBORycsCiAgICAgICAgJy4vMTEuUE5HJywKICAgICAgICAnLi8xMi5QTkcnCiAgICAgXSk7ICAgIAogICAgfSkKICApOwp9KTsKCnNlbGYuYWRkRXZlbnRMaXN0ZW5lcignZmV0Y2gnLCBlID0+IHsKICBlLnJlc3BvbmRXaXRoKAogICAgY2FjaGVzLm1hdGNoKGUucmVxdWVzdCkudGhlbihyZXNwb25zZSA9PiB7CiAgICAgIHJldHVybiByZXNwb25zZSB8fCBmZXRjaChlLnJlcXVlc3QpOwogICAgfSkKICApOwp9KTs=')
+    navigator.serviceWorker.register('/sw.js')
       .then(registration => {
         console.log('SW registered: ', registration);
       })

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,25 @@
+const CACHE_NAME = 'animal-tower-v1';
+const PRECACHE_URLS = [
+  '/',
+  '/index.html',
+  '/sample/matter.min.js'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME)
+      .then(cache => cache.addAll(PRECACHE_URLS))
+      .catch(err => {
+        // キャッシュ失敗時でもインストールを継続
+        console.error('Precache failed:', err);
+      })
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => {
+      return response || fetch(event.request);
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- move service worker script out of inline base64 into sw.js
- trim precache list to essential files only
- add install error handling to avoid cache failures blocking registration

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689cdd5cead083329c910be1baf7deaf