### PR TITLE
Use relative paths for service worker

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,7 +1,7 @@
 // Service Worker登録
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.js')
+    navigator.serviceWorker.register('./sw.js')
       .then(registration => {
         console.log('SW registered: ', registration);
       })

--- a/sw.js
+++ b/sw.js
@@ -1,12 +1,12 @@
 const CACHE_NAME = 'animal-tower-v2';
 const PRECACHE_URLS = [
-  '/',
-  '/index.html',
-  '/styles.css',
-  '/main.js',
-  '/public/manifest.json',
-  '/public/icon.svg',
-  '/sample/matter.min.js'
+  './',
+  'index.html',
+  'styles.css',
+  'main.js',
+  'public/manifest.json',
+  'public/icon.svg',
+  'sample/matter.min.js'
 ];
 
 self.addEventListener('install', event => {


### PR DESCRIPTION
## Summary
- register service worker using a relative path
- use relative paths in service worker precache list

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d6204717c8332bf94b8ff434cc33f