### PR TITLE
feat: clean old caches on activation

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -20,6 +20,18 @@ self.addEventListener('install', event => {
   );
 });
 
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(
+        keys
+          .filter(key => key !== CACHE_NAME)
+          .map(key => caches.delete(key))
+      )
+    )
+  );
+});
+
 self.addEventListener('fetch', event => {
   event.respondWith(
     caches.match(event.request).then(response => {


### PR DESCRIPTION
## Summary
- remove outdated caches during service worker activation so old CACHE_NAME entries are purged automatically

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d62b0baf88332857d10935a210736