### PR TITLE
Replace Apple web app meta tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 <link rel="manifest" href="public/manifest.json">
 
 <meta name="theme-color" content="#4169E1">
-<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-status-bar-style" content="default">
 <meta name="apple-mobile-web-app-title" content="Animal Tower">
 <link rel="apple-touch-icon" href="public/icon.svg">


### PR DESCRIPTION
## Summary
- replace `apple-mobile-web-app-capable` meta tag with `mobile-web-app-capable`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d6b8c19408332a489a7fdb4fcba8c