### PR TITLE
Use CDN for Matter.js 0.19.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
   </div>
 </div>
 
-<script src="sample/matter.min.js" defer></script>
+<script src="https://cdn.jsdelivr.net/npm/matter-js@0.19.0/build/matter.min.js" defer></script>
 <script src="main.js" defer></script>
 </body>
 </html>

--- a/sample/matter.min.js
+++ b/sample/matter.min.js
@@ -1,1 +1,0 @@
-// Placeholder for Matter.js 0.19.0 - download required.

--- a/sw.js
+++ b/sw.js
@@ -6,7 +6,7 @@ const PRECACHE_URLS = [
   'main.js',
   'public/manifest.json',
   'public/icon.svg',
-  'sample/matter.min.js'
+  'https://cdn.jsdelivr.net/npm/matter-js@0.19.0/build/matter.min.js'
 ];
 
 self.addEventListener('install', event => {


### PR DESCRIPTION
## Summary
- load Matter.js 0.19.0 from jsDelivr CDN
- update service worker cache list
- remove placeholder Matter.js file

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d725732dc83329ce8cf94c8f07402