### PR TITLE
Enable play-again button after game over

### DIFF
--- a/main.js
+++ b/main.js
@@ -175,25 +175,32 @@ function triggerGameOver() {
     if (gameState.gameOver) return;
     
     gameState.gameOver = true;
-    
+
       // UI更新
+    const controls = document.getElementById('controls');
+    const resetBtn = document.getElementById('resetBtn');
+
     document.getElementById('gameOverText').style.display = 'block';
-    document.getElementById('controls').classList.add('game-over');
-    
+    controls.classList.add('game-over');
+
+    // 操作ボタンを一時的に無効化
+    controls.querySelectorAll('button').forEach(btn => btn.disabled = true);
+
     // エンジンを停止
     if (gameState.runner) {
         Runner.stop(gameState.runner);
     }
-    
+
     // 現在の動物をクリア
     gameState.currentBody = null;
     gameState.isDropping = false;
-    
+
     console.log('ゲームオーバー！ 最終スコア:', gameState.score);
-    
-    // 3秒後にリセットボタンを強調
+
+    // 3秒後にリセットボタンを強調して有効化
     setTimeout(() => {
-        const resetBtn = document.getElementById('resetBtn');
+        controls.classList.remove('game-over');
+        resetBtn.disabled = false;
         resetBtn.style.background = 'linear-gradient(145deg, #ff6b6b, #ff5252)';
         resetBtn.style.color = 'white';
         resetBtn.textContent = '🔄 もう一度プレイ';

--- a/styles.css
+++ b/styles.css
@@ -76,7 +76,6 @@
   
   .game-over {
     opacity: 0.6;
-    pointer-events: none;
   }
   
   .loading {


### PR DESCRIPTION
## Summary
- Ensure control buttons disable on game over while re-enabling the reset button after a short delay
- Remove pointer-events blocking from game-over styling so the retry button becomes clickable

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d751211b883329250529415fd6ee1