### PR TITLE
Add background music with user-controlled playback

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@
     <div id="loadingText" class="loading">画像を読み込み中...</div>
     <button id="retryBtn" style="display: none;">再試行</button>
     <div id="gameOverText" style="display: none; color: #ff0000; font-size: 24px; font-weight: bold;">ゲームオーバー！</div>
+    <button id="muteBtn">🔇 ミュート</button>
   </div>
   
   <button id="installPrompt">📱 アプリとしてインストール</button>
@@ -43,5 +44,6 @@
 
 <script src="https://cdn.jsdelivr.net/npm/matter-js@0.19.0/build/matter.min.js" defer></script>
 <script src="main.js" defer></script>
+<audio id="bgm" src="Kanpiro.mp3" loop></audio>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -1,3 +1,33 @@
+const bgm = document.getElementById('bgm');
+
+function startBGM() {
+    bgm.play().catch(err => console.log('BGM play failed', err));
+}
+
+document.body.addEventListener('touchstart', startBGM, { once: true });
+document.body.addEventListener('click', startBGM, { once: true });
+
+const muteBtn = document.getElementById('muteBtn');
+if (muteBtn) {
+    muteBtn.addEventListener('click', () => {
+        if (bgm.paused) {
+            bgm.play().catch(err => console.log('BGM play failed', err));
+        } else {
+            bgm.pause();
+        }
+    });
+}
+
+document.addEventListener('keydown', (e) => {
+    if (e.key.toLowerCase() === 'm') {
+        if (bgm.paused) {
+            bgm.play().catch(err => console.log('BGM play failed', err));
+        } else {
+            bgm.pause();
+        }
+    }
+});
+
 // Service Worker登録
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {


### PR DESCRIPTION
## Summary
- Add background music audio element and mute button
- Start playback after first touch/click and allow toggling via button or `m`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d9eed45f48332b5e31d39fb80f131