### PR TITLE
Ensure BGM preloads and supports keyboard start

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,6 @@
 
 <script src="https://cdn.jsdelivr.net/npm/matter-js@0.19.0/build/matter.min.js" defer></script>
 <script src="main.js" defer></script>
-<audio id="bgm" src="Kanpiro.mp3" loop></audio>
+<audio id="bgm" src="Kanpiro.mp3" loop preload="auto"></audio>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -1,11 +1,13 @@
 const bgm = document.getElementById('bgm');
 
 function startBGM() {
+    console.log('startBGM triggered');
     bgm.play().catch(err => console.log('BGM play failed', err));
 }
 
 document.body.addEventListener('touchstart', startBGM, { once: true });
 document.body.addEventListener('click', startBGM, { once: true });
+window.addEventListener('keydown', startBGM, { once: true });
 
 const muteBtn = document.getElementById('muteBtn');
 if (muteBtn) {


### PR DESCRIPTION
## Summary
- Preload background music to improve startup reliability.
- Log when `startBGM` triggers and add keyboard event listener for first keydown.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689da17066d48332bef740e3ba7dbcf3