### PR TITLE
Add universal audio gesture handling with prompt overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,8 @@
 <body>
 <div class="pwa-info">PWA対応版</div>
 
+<div id="audioPrompt">🔊 タップして音をオン</div>
+
 <div id="gameContainer">
   <div id="gameInfo">
     <div>カンピロぐらぐら</div>
@@ -44,6 +46,6 @@
 
 <script src="https://cdn.jsdelivr.net/npm/matter-js@0.19.0/build/matter.min.js" defer></script>
 <script src="main.js" defer></script>
-<audio id="bgm" src="Kanpiro.mp3" loop preload="auto"></audio>
+<audio id="bgm" src="Kanpiro.mp3" loop preload="auto" playsinline></audio>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -2,10 +2,16 @@ const bgm = document.getElementById('bgm');
 
 function startBGM() {
     console.log('startBGM triggered');
-    bgm.play().catch(err => console.log('BGM play failed', err));
+    bgm.play().then(() => {
+        const prompt = document.getElementById('audioPrompt');
+        if (prompt) {
+            prompt.style.display = 'none';
+        }
+    }).catch(err => console.log('BGM play failed', err));
 }
 
-document.body.addEventListener('touchstart', startBGM, { once: true });
+window.addEventListener('touchstart', startBGM, { once: true });
+window.addEventListener('pointerdown', startBGM, { once: true });
 document.body.addEventListener('click', startBGM, { once: true });
 window.addEventListener('keydown', startBGM, { once: true });
 


### PR DESCRIPTION
## Summary
- Ensure background music plays inline and prompt users to enable audio
- Hide tap-to-enable overlay once audio starts and handle touch/pointer gestures

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689da3b0233c8332bc5a8bff02848835