### PR TITLE
Remove horizontal movement limits

### DIFF
--- a/main.js
+++ b/main.js
@@ -417,12 +417,7 @@ function setupEventListeners() {
         // 落下していない場合は重力を無効化
         if (gameState.currentBody && !gameState.isDropping && !gameState.gameOver) {
             Body.setVelocity(gameState.currentBody, { x: 0, y: 0 });
-            Body.setPosition(gameState.currentBody, {
-                x: Math.max(gameState.currentBody.bounds.max.x - gameState.currentBody.bounds.min.x, 
-                          Math.min(GAME_CONFIG.canvas.width - (gameState.currentBody.bounds.max.x - gameState.currentBody.bounds.min.x), 
-                                  gameState.currentBody.position.x)),
-                y: gameState.currentBody.position.y
-            });
+            // Removed horizontal position clamping to allow free movement
         }
         
         // 落下中の動物が静止したら次の動物を生成


### PR DESCRIPTION
## Summary
- remove Body.setPosition clamping in beforeUpdate listener to allow free horizontal movement

## Testing
- `node --check main.js`
- `npm test` *(fails: no such file or directory, open '/workspace/moura_tower/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689da8e6c3408332b32cd0d7b8bffa35