### PR TITLE
Add allow-list filtering to polygon extraction script

### DIFF
--- a/scripts/extract_polygon.js
+++ b/scripts/extract_polygon.js
@@ -213,7 +213,13 @@ function processImages() {
   const imageDir = path.resolve('.');
   const polygonDir = path.join(imageDir, 'polygons');
   fs.mkdirSync(polygonDir, { recursive: true });
-  const files = fs.readdirSync(imageDir).filter(f => f.toLowerCase().endsWith('.png'));
+  const allFiles = fs.readdirSync(imageDir).filter(f => f.toLowerCase().endsWith('.png'));
+  const allowList = (process.argv.slice(2).length > 0
+    ? process.argv.slice(2)
+    : ['100.PNG','101.PNG','102.PNG','103.PNG','104.PNG','105.PNG']
+  ).map(f => f.toLowerCase());
+  const files = allFiles.filter(f => allowList.includes(f.toLowerCase()));
+
   files.forEach(file => {
     const filePath = path.join(imageDir, file);
     const buffer = fs.readFileSync(filePath);


### PR DESCRIPTION
## Summary
- Restrict PNG processing to an allow-list, optionally via CLI arguments
- Regenerate polygon JSON files for the permitted images

## Testing
- `node scripts/extract_polygon.js 100.PNG 101.PNG 102.PNG 103.PNG 104.PNG 105.PNG`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0394f03f08332ae142ffe9835ac1e